### PR TITLE
Simple patch for new shortcut keys!

### DIFF
--- a/reviewboard/htdocs/media/rb/js/diffviewer.js
+++ b/reviewboard/htdocs/media/rb/js/diffviewer.js
@@ -73,6 +73,25 @@ var gActions = [
     { // Go to footer
         keys: "GU:",
         onPress: function() {}
+    },
+
+    { // Show review form
+        keys: "r",
+        onPress: function() { $.reviewForm(); }
+    },
+
+    { // Submit shipit review
+        keys: "R",
+        onPress: function() {
+          var data = {
+            path: getReviewDraftAPIPath() + "/publish/",
+            data: {shipit: 1},
+            success: function() {
+              window.location = gReviewRequestPath;
+            }
+          };
+          reviewRequestApiCall(data);
+        }
     }
 ];
 


### PR DESCRIPTION
Hi, here's a tiny patch that adds two shortcut keys into diffviewer.js which have completely changed our lives:
- Hitting r is a shortcut for clicking 'Review', bringing up the review-editing pop-up.
- Hitting shift+r is a shortcut for clicking 'Review', checking 'Ship It', and clicking 'Publish Review', for quickly signing off on simple diffs much more efficiently.

Hope you pull these changes. Thanks!
