### PR TITLE
Fixes bug 2134

### DIFF
--- a/reviewboard/scmtools/svn.py
+++ b/reviewboard/scmtools/svn.py
@@ -170,7 +170,7 @@ class SVNTool(SCMTool):
 
         # Get any aliased keywords
         keywords = [keyword
-                    for name in keyword_str.split(" ")
+                    for name in re.split("\W+",keyword_str)
                     for keyword in self.keywords.get(name, [])]
 
         return re.sub(r"\$(%s):(:?)([^\$\n\r]+)\$" % '|'.join(keywords),
@@ -246,6 +246,8 @@ class SVNTool(SCMTool):
     def __normalize_path(self, path):
         if path.startswith(self.repopath):
             return path
+        elif path[0:2] == '//':
+            return self.repopath + path[1:]
         elif path[0] == '/':
             return self.repopath + path
         else:


### PR DESCRIPTION
diffs were being created for files where the area surrounding keywords
had changed, and the keywords were not being collapsed.  This was
happening for two reasons:
- it couldn't understand paths with two leading slashes
- `svn propget svn:keywords` can return strings with non-space delimiters
