### PR TITLE
Adding feeds (django 1.4)

### DIFF
--- a/reviewboard/reviews/feeds.py
+++ b/reviewboard/reviews/feeds.py
@@ -1,0 +1,95 @@
+from django.contrib.auth.models import User
+from django.contrib.sites.models import Site
+from django.contrib.syndication.views import Feed
+from django.core.exceptions import ObjectDoesNotExist
+from django.utils.feedgenerator import Atom1Feed
+from django.shortcuts import get_object_or_404
+from djblets.siteconfig.models import SiteConfiguration
+
+from reviewboard.reviews.models import Group, ReviewRequest
+
+def add_domain(url):
+    if not (url.startswith("http://") or url.startswith("https://")):
+        siteconfig = SiteConfiguration.objects.get_current()
+        url = "%s://%s%s" % (siteconfig.get("site_domain_method"),
+                             Site.objects.get_current().domain,
+                             url)
+
+    return url
+
+class BaseReviewFeed(Feed):
+    title_template = "feeds/reviews_title.html"
+    description_template = "feeds/reviews_description.html"
+
+    def item_author_link(self, item):
+        return add_domain(item.submitter.get_absolute_url())
+
+    def item_author_name(self, item):
+        return item.submitter.username
+
+    def item_author_email(self, item):
+        return item.submitter.email
+
+    def item_pubdate(self, item):
+        return item.last_updated
+
+    def item_link(self, obj):
+        return add_domain(obj.get_absolute_url())
+
+
+# RSS Feeds
+class RssReviewsFeed(BaseReviewFeed):
+    title = "Review Requests"
+    link = "/r"
+    description = "All pending review requests."
+
+    def items(self):
+        return ReviewRequest.objects.public()[:20]
+
+
+class RssSubmitterReviewsFeed(BaseReviewFeed):
+
+    def get_object(self, request, username):
+        return get_object_or_404(User, username=username)
+
+    def title(self, submitter):
+        return u"Review requests to %s" % submitter
+
+    def link(self, submitter):
+        return add_domain(submitter.get_absolute_url())
+
+    def description(self, submitter):
+        return u"Pending review requests to %s" % submitter
+
+    def items(self, submitter):
+        return ReviewRequest.objects.to_user_directly(submitter.username).\
+            order_by('-last_updated')[:20]
+
+
+class RssGroupReviewsFeed(BaseReviewFeed):
+    def get_object(self, request, groupname):
+        return get_object_or_404(Group, name=groupname)
+
+    def title(self, group):
+        return u"Review requests to group %s" % group
+
+    def link(self, group):
+        return add_domain(group.get_absolute_url())
+
+    def description(self, group):
+        return u"Pending review requests to %s" % group
+
+    def items(self, group):
+        return ReviewRequest.objects.to_group(group).\
+            order_by('-last_updated')[:20]
+
+
+# Atom feeds
+class AtomReviewsFeed(RssReviewsFeed):
+    feed_type = Atom1Feed
+
+class AtomSubmitterReviewsFeed(RssSubmitterReviewsFeed):
+    feed_type = Atom1Feed
+
+class AtomGroupReviewsFeed(RssGroupReviewsFeed):
+    feed_type = Atom1Feed

--- a/reviewboard/reviews/urls.py
+++ b/reviewboard/reviews/urls.py
@@ -1,7 +1,9 @@
 from django.conf.urls.defaults import patterns, url
+from reviewboard.reviews.feeds import RssReviewsFeed
 
 urlpatterns = patterns('reviewboard.reviews.views',
     url(r'^$', 'all_review_requests', name="all-review-requests"),
+    (r'^feed/$', RssReviewsFeed()),
 
     # Review request creation
     url(r'^new/$', 'new_review_request', name="new-review-request"),

--- a/reviewboard/urls.py
+++ b/reviewboard/urls.py
@@ -4,7 +4,7 @@ from django.contrib import admin
 
 from reviewboard.webapi.resources import root_resource
 from reviewboard import initialize
-
+from reviewboard.reviews.feeds import RssSubmitterReviewsFeed
 
 initialize()
 
@@ -43,6 +43,8 @@ localsite_urlpatterns = patterns('',
     # Dashboard
     url(r'^dashboard/$',
         'reviewboard.reviews.views.dashboard', name="dashboard"),
+    url(r'^dashboard/feed/(?P<username>[A-Za-z0-9@_\-\.]+)/$', 
+     RssSubmitterReviewsFeed(), name="submitter-feeds"),
 
     # Users
     url(r'^users/$',


### PR DESCRIPTION
It is based on the old feeds.py file removed in 2009 when django feeds evolved in 1.4.

Only working for all reviews in /r or for user in his /dashboard/feed/<username> because I don't need other feeds right now.

It might need some rework to place the feeds in a more stable/nice url place
