### PR TITLE
Make Chrome wrap very long lines with no spaces

### DIFF
--- a/reviewboard/static/rb/css/defs.less
+++ b/reviewboard/static/rb/css/defs.less
@@ -84,6 +84,7 @@
   white-space: -pre-wrap;     /* Opera 4-6 */
   white-space: -o-pre-wrap;   /* Opera 7 */
   word-wrap: break-word;      /* IE 5.5+ */
+  word-break: break-all;      /* Chrome */
 }
 
 // vim: set et ts=2 sw=2:


### PR DESCRIPTION
Chrome does not currently wrap very long lines with no spaces (though
Firefox does).

This makes the diff view unusable since one such line will cause all
other long lines to also not break, even if they do have spaces. The
result is that  you have to scroll to read every line that is longer than
what fits in the split diff view.

(I agree that in a perfect world all code would be hard-wrapped at
80 characters, and there would be no long lines without spaces.)
