### PR TITLE
Added new option to send mail for a ship-it

### DIFF
--- a/reviewboard/admin/forms.py
+++ b/reviewboard/admin/forms.py
@@ -325,6 +325,9 @@ class EMailSettingsForm(SiteSettingsForm):
     mail_send_review_mail = forms.BooleanField(
         label=_("Send e-mails for review requests and reviews"),
         required=False)
+    mail_send_shipit_mail = forms.BooleanField(
+        label=_("Send e-mails for ship-its"),
+        required=False)
     mail_send_new_user_mail = forms.BooleanField(
         label=_("Send e-mails when new users register an account"),
         required=False)

--- a/reviewboard/admin/siteconfig.py
+++ b/reviewboard/admin/siteconfig.py
@@ -125,6 +125,7 @@ defaults.update({
     'diffviewer_syntax_highlighting_threshold': 0,
     'diffviewer_show_trailing_whitespace': True,
     'mail_send_review_mail':               False,
+    'mail_send_shipit_mail':               False,
     'mail_send_new_user_mail':             False,
     'search_enable':                       False,
     'site_domain_method':                  'http',

--- a/reviewboard/notifications/email.py
+++ b/reviewboard/notifications/email.py
@@ -34,7 +34,11 @@ def review_published_cb(sender, user, review, **kwargs):
     ``mail_send_review_mail`` site configuration).
     """
     siteconfig = SiteConfiguration.objects.get_current()
-    if siteconfig.get("mail_send_review_mail"):
+    
+    if review.ship_it:
+        if siteconfig.get("mail_send_shipit_mail"):
+            mail_review(user, review)
+    elif siteconfig.get("mail_send_review_mail"):
         mail_review(user, review)
 
 


### PR DESCRIPTION
Added an option to allow to send or not an email when a reviewer marks a review as shippable.
