### PR TITLE
don't expect script to be executable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ class BuildMedia(Command):
         pass
 
     def run(self):
-        retcode = subprocess.call(['./contrib/internal/build-media.py'])
+        retcode = subprocess.call(['python', 'contrib/internal/build-media.py'])
 
         if retcode != 0:
             raise RuntimeError('Failed to build media files')


### PR DESCRIPTION
When installing from pip, the `build-media.py` script is not executable, so we invoke Python explicitly.
