### PR TITLE
Fix a major boo-boo in the 1.7.7 release

### DIFF
--- a/reviewboard/cmdline/rbsite.py
+++ b/reviewboard/cmdline/rbsite.py
@@ -613,11 +613,11 @@ class Site(object):
 
         data = {
             'rbsite': rbsite_path,
-            'port': self.web_server_port,
+            'port': str(self.web_server_port),
             'sitedir': sitedir,
             'sitedomain': self.domain_name,
             'sitedomain_escaped': domain_name_escaped,
-            'siteid': self.site_id,
+            'siteid': str(self.site_id),
             'siteroot': self.site_root,
             'siteroot_noslash': self.site_root[1:-1],
         }


### PR DESCRIPTION
The port being an integer blows up as the regex expects a string resulting in a TypeError.

When _not_ specifying the port via rb-site install, it blows up.

``` python
* Installing the site...
Building site directories ... OK
Building site configuration files ... Traceback (most recent call last):
  File "/home/venvs/bin/rb-site", line 8, in <module>
    load_entry_point('ReviewBoard==1.7.7', 'console_scripts', 'rb-site')()
  File "/home/venvs/lib/python2.7/site-packages/ReviewBoard-1.7.7-py2.7.egg/reviewboard/cmdline/rbsite.py", line 1937, in main
    command.run()
  File "/home/venvs/lib/python2.7/site-packages/ReviewBoard-1.7.7-py2.7.egg/reviewboard/cmdline/rbsite.py", line 1405, in run
    self.show_install_status()
  File "/home/venvs/lib/python2.7/site-packages/ReviewBoard-1.7.7-py2.7.egg/reviewboard/cmdline/rbsite.py", line 1682, in show_install_status
    site.generate_config_files)
  File "/home/venvs/lib/python2.7/site-packages/ReviewBoard-1.7.7-py2.7.egg/reviewboard/cmdline/rbsite.py", line 885, in step
    func()
  File "/home/venvs/lib/python2.7/site-packages/ReviewBoard-1.7.7-py2.7.egg/reviewboard/cmdline/rbsite.py", line 290, in generate_config_files
    os.path.join(conf_dir, web_conf_filename))
  File "/home/venvs/lib/python2.7/site-packages/ReviewBoard-1.7.7-py2.7.egg/reviewboard/cmdline/rbsite.py", line 626, in process_template
    template)
  File "/home/venvs/lib/python2.7/re.py", line 151, in sub
    return _compile(pattern, flags).sub(repl, string, count)
TypeError: sequence item 1: expected string, int found
```

I verified this patch works as expected with the port. For kicks, I added a cast to str for the site_id, but that is just for good measure. The port is what blows up for me.

My invocation of rb-site:

``` bash
rb-site install \
  --copy-media \
  --noinput \
  --domain-name="${vhost}.${domain}" \
  --site-root=/ \
  --static-url=static/ \
  --media-url=media/ \
  --db-type=mysql \
  --db-name="$database" \
  --db-host=localhost \
  --db-user="$team" \
  --db-pass="$password" \
  --cache-type=memcached \
  --cache-info="localhost:11211" \
  --web-server-type=apache \
  --python-loader=wsgi \
"${basedir}/$vhost"
```
