### PR TITLE
Change max value of hosting_url to 255

### DIFF
--- a/reviewboard/hostingsvcs/evolutions/account_hosting_url.py
+++ b/reviewboard/hostingsvcs/evolutions/account_hosting_url.py
@@ -4,5 +4,5 @@ from django.db import models
 
 MUTATIONS = [
     AddField('HostingServiceAccount', 'hosting_url', models.CharField,
-             max_length=256, null=True)
+             max_length=255, null=True)
 ]

--- a/reviewboard/hostingsvcs/models.py
+++ b/reviewboard/hostingsvcs/models.py
@@ -9,7 +9,7 @@ from reviewboard.site.models import LocalSite
 
 class HostingServiceAccount(models.Model):
     service_name = models.CharField(max_length=128)
-    hosting_url = models.CharField(max_length=256, blank=True, null=True)
+    hosting_url = models.CharField(max_length=255, blank=True, null=True)
     username = models.CharField(max_length=128)
     data = JSONField()
     visible = models.BooleanField(default=True)


### PR DESCRIPTION
The current value (256) makes the size of the row too big for MySQL InnoDB engine, resulting in this error:

django.db.utils.DatabaseError: Specified key was too long; max key length is 767 bytes

As the RFC (http://www.ietf.org/rfc/rfc1035.txt) fix this value to 255 as bigger, and it is enough to avoid the issue with InnoDB, it would be great to change it.

Thank you in advance.
