### PR TITLE
Make crypto_utils backwards compatible with python-crypto

### DIFF
--- a/reviewboard/scmtools/crypto_utils.py
+++ b/reviewboard/scmtools/crypto_utils.py
@@ -1,5 +1,8 @@
 import base64
-from Crypto import Random
+try:
+    from Crypto import Random
+except ImportError:
+    from Crypto.Util.randpool import RandomPool as Random
 from Crypto.Cipher import AES
 from django.conf import settings
 


### PR DESCRIPTION
shipped on CentOS 6.4

This resolves GoogleCode Issue 3110.

Sponsored-by: Zonar Systems, Inc
Signed-off-by: Garrett Cooper yanegomi@gmail.com
