### PR TITLE
(enhancement) allow management commands inside RB extensions

### DIFF
--- a/reviewboard/cmdline/rbsite.py
+++ b/reviewboard/cmdline/rbsite.py
@@ -543,7 +543,11 @@ class Site(object):
 
         try:
             from django.core.management import execute_manager, get_commands
+            from reviewboard.extensions.base import get_extension_manager
             import reviewboard.settings
+
+            extensionmanager=get_extension_manager()
+            extensionmanager.load()
 
             if not params:
                 params = []


### PR DESCRIPTION
Now rbsite picks up management commands only from installed applications, i.e. rbsite doesn't take extensions into account. To fix it, rbsite can load all extensions before generating list of management commands.
