### PR TITLE
Patch for ticket 4009

### DIFF
--- a/reviewboard/webapi/resources/review_request.py
+++ b/reviewboard/webapi/resources/review_request.py
@@ -567,7 +567,7 @@ class ReviewRequestResource(MarkdownFieldsMixin, WebAPIResource):
     )
     def create(self, request, repository=None, submit_as=None, changenum=None,
                commit_id=None, local_site_name=None,
-               create_from_commit_id=False, branch=None, extra_fields={},
+               create_from_commit_id=False, branch="", extra_fields={},
                *args, **kwargs):
         """Creates a new review request.
 


### PR DESCRIPTION
Changed default value for branch as the None value will be inserted to MySQL if it's not sent when creating a review. I tried this change on our server and it looks to fix the null exception.

This is to try and solve the ticket 4009