### PR TITLE
Fix ticket 4438: email header is too large for big file changesets

### DIFF
--- a/reviewboard/notifications/email.py
+++ b/reviewboard/notifications/email.py
@@ -599,9 +599,6 @@ def send_review_mail(user, review_request, subject, in_reply_to,
             if filediff.is_new or filediff.copied or filediff.moved:
                 modified_files.add(filediff.dest_file)
 
-        for filename in modified_files:
-            headers.appendlist('X-ReviewBoard-Diff-For', filename)
-
     subject = subject.strip()
     to_field = list(to_field)
     cc_field = list(cc_field)


### PR DESCRIPTION
Fix for ticket-4438:
Email header is too large when too many changed files
https://hellosplat.com/s/beanbag/tickets/4438/