### PR TITLE
docs: fix simple typo, succes -> success

### DIFF
--- a/reviewboard/static/rb/js/resources/models/reviewGroupModel.es6.js
+++ b/reviewboard/static/rb/js/resources/models/reviewGroupModel.es6.js
@@ -127,7 +127,7 @@ RB.ReviewGroup = RB.BaseResource.extend({
      * Add a user to this group.
      *
      * Sends the request to the server to add the user, and notifies on
-     * succes or failure.
+     * success or failure.
      *
      * Args:
      *     username (string):
@@ -160,7 +160,7 @@ RB.ReviewGroup = RB.BaseResource.extend({
      * Remove a user from this group.
      *
      * Sends the request to the server to remove the user, and notifies on
-     * succes or failure.
+     * success or failure.
      *
      * Args:
      *     username (string):


### PR DESCRIPTION
There is a small typo in reviewboard/static/rb/js/resources/models/reviewGroupModel.es6.js.

Should read `success` rather than `succes`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md