### PR TITLE
Use LOGGING_LEVEL in Docker!

### DIFF
--- a/contrib/docker/scripts/serve.sh
+++ b/contrib/docker/scripts/serve.sh
@@ -3,7 +3,7 @@
 gunicorn \
     --bind=0.0.0.0:8080 \
     --worker-tmp-dir=/dev/shm \
-    --log-level=debug \
+    --log-level=${LOGGING_LEVEL} \
     --log-file=- \
     --timeout=${REQUEST_TIMEOUT} \
     --workers=${NUM_WORKERS} \

--- a/contrib/docker/scripts/serve.sh
+++ b/contrib/docker/scripts/serve.sh
@@ -3,7 +3,7 @@
 gunicorn \
     --bind=0.0.0.0:8080 \
     --worker-tmp-dir=/dev/shm \
-    --log-level=${LOGGING_LEVEL} \
+    --log-level=${LOGGING_LEVEL:-debug} \
     --log-file=- \
     --timeout=${REQUEST_TIMEOUT} \
     --workers=${NUM_WORKERS} \


### PR DESCRIPTION
In docker LOGGING_LEVEL was not used, and always set to DEBUG (hard-coded). 

Even in production! So I was unable to manage this, causing unnecessary calls to syslog as well (if you log docker to syslog).