### PR TITLE
SSO improvements (custom NameID format + custom attributes)

### DIFF
--- a/docs/manual/admin/configuration/authentication-settings.rst
+++ b/docs/manual/admin/configuration/authentication-settings.rst
@@ -255,6 +255,7 @@ Review Board configuration:
    each.
 2. A copy of the X.509 certificate.
 3. Possibly, specific digest and signature algorithm types.
+4. NameID attribute format compatible with your IdP.
 
 The :guilabel:`Require login to link` setting allows you to control the
 behavior when first authenticating a user via SSO who already has an account on

--- a/reviewboard/accounts/sso/backends/saml/forms.py
+++ b/reviewboard/accounts/sso/backends/saml/forms.py
@@ -16,7 +16,8 @@ from djblets.siteconfig.forms import SiteSettingsForm
 from reviewboard.accounts.sso.backends.saml.settings import (
     SAMLBinding,
     SAMLDigestAlgorithm,
-    SAMLSignatureAlgorithm)
+    SAMLSignatureAlgorithm,
+    NameIDFormat)
 
 
 class SAMLLinkUserForm(AuthenticationForm):
@@ -129,6 +130,11 @@ class SAMLSettingsForm(SiteSettingsForm):
         choices=SAMLBinding.CHOICES,
         initial=SAMLBinding.HTTP_REDIRECT)
 
+    saml_nameid_format = forms.ChoiceField(
+        label=_('NameID format'),
+        choices=NameIDFormat.CHOICES,
+        initial=NameIDFormat.PERSISTENT)
+
     saml_require_login_to_link = forms.BooleanField(
         label=_('Require login to link'),
         help_text=_('When a matching user is found, ask them to log in with '
@@ -152,6 +158,7 @@ class SAMLSettingsForm(SiteSettingsForm):
                            'saml_sso_binding_type',
                            'saml_slo_url',
                            'saml_slo_binding_type',
+                           'saml_nameid_format',
                            'saml_require_login_to_link'),
             }),
         )

--- a/reviewboard/accounts/sso/backends/saml/forms.py
+++ b/reviewboard/accounts/sso/backends/saml/forms.py
@@ -17,7 +17,8 @@ from reviewboard.accounts.sso.backends.saml.settings import (
     SAMLBinding,
     SAMLDigestAlgorithm,
     SAMLSignatureAlgorithm,
-    NameIDFormat)
+    NameIDFormat,
+    UserAttributeMapping)
 
 
 class SAMLLinkUserForm(AuthenticationForm):
@@ -143,6 +144,42 @@ class SAMLSettingsForm(SiteSettingsForm):
                     'sending the correct username for all existing users.'),
         required=False)
 
+    saml_email_attribute_name = forms.CharField(
+        label=_('Custom `Email` attribute name'),
+        min_length=1,
+        required=True,
+        initial=UserAttributeMapping.EMAIL,
+        help_text=_('Sometimes you can not modify SAML attributes returned '
+                    'by your IdP. You may set custom `Email` attribute name. '
+                    'Make sure your setting corresponds with your IdP '
+                    'SAML response. Default value is '
+                    f"{UserAttributeMapping.EMAIL}"),
+        widget=forms.TextInput(attrs={'size': '60'}))
+
+    saml_firstname_attribute_name = forms.CharField(
+        label=_('Custom `First Name` attribute name'),
+        min_length=1,
+        required=True,
+        initial=UserAttributeMapping.FIRSTNAME,
+        help_text=_('Sometimes you can not modify SAML attributes returned '
+                    'by your IdP. You may set custom `First Name` attribute name. '
+                    'Make sure your setting corresponds with your IdP '
+                    'SAML response. Default value is '
+                    f"{UserAttributeMapping.FIRSTNAME}"),
+        widget=forms.TextInput(attrs={'size': '60'}))
+
+    saml_lastname_attribute_name = forms.CharField(
+        label=_('Custom `Last Name` attribute name'),
+        min_length=1,
+        required=True,
+        initial=UserAttributeMapping.LASTNAME,
+        help_text=_('Sometimes you can not modify SAML attributes returned '
+                    'by your IdP. You may set custom `First Name` attribute name. '
+                    'Make sure your setting corresponds with your IdP '
+                    'SAML response. Default value is '
+                    f"{UserAttributeMapping.LASTNAME}"),
+        widget=forms.TextInput(attrs={'size': '60'}))
+
     class Meta:
         """Metadata for the SAMLSettingsForm."""
 
@@ -159,6 +196,9 @@ class SAMLSettingsForm(SiteSettingsForm):
                            'saml_slo_url',
                            'saml_slo_binding_type',
                            'saml_nameid_format',
-                           'saml_require_login_to_link'),
+                           'saml_require_login_to_link',
+                           'saml_email_attribute_name',
+                           'saml_firstname_attribute_name',
+                           'saml_lastname_attribute_name'),
             }),
         )

--- a/reviewboard/accounts/sso/backends/saml/settings.py
+++ b/reviewboard/accounts/sso/backends/saml/settings.py
@@ -166,6 +166,19 @@ class NameIDFormat(object):
         TO_SAML2_SETTING_MAP = {}
         FROM_SAML2_SETTING_MAP = {}
 
+
+class UserAttributeMapping(object):
+    """Definitions for the UserAttributeMapping.
+
+    Version Added:
+        5.0
+    """
+
+    EMAIL = 'User.email'
+    FIRSTNAME = 'User.FirstName'
+    LASTNAME = 'User.LastName'
+
+
 def get_saml2_settings():
     """Return the SAML2.0 settings.
 

--- a/reviewboard/accounts/sso/backends/saml/settings.py
+++ b/reviewboard/accounts/sso/backends/saml/settings.py
@@ -125,6 +125,47 @@ class SAMLBinding(object):
         FROM_SAML2_SETTING_MAP = {}
 
 
+class NameIDFormat(object):
+    """Definitions for the NameIDFormat.
+
+    Version Added:
+        5.0
+    """
+
+    EMAIL = 'email'
+    ENTITY = 'entity'
+    TRANSIENT = 'transient'
+    PERSISTENT = 'persistent'
+    UNSPECIFIED = 'unspecified'
+
+    CHOICES = (
+        (EMAIL, _('emailAddress')),
+        (ENTITY, _('entity')),
+        (TRANSIENT, _('transient')),
+        (PERSISTENT, _('persistent')),
+        (UNSPECIFIED, _('unspecified')),
+    )
+
+    if constants:
+        TO_SAML2_SETTING_MAP = {
+            EMAIL: constants.NAMEID_EMAIL_ADDRESS,
+            ENTITY: constants.NAMEID_ENTITY,
+            TRANSIENT: constants.NAMEID_TRANSIENT,
+            PERSISTENT: constants.NAMEID_PERSISTENT,
+            UNSPECIFIED: constants.NAMEID_UNSPECIFIED,
+        }
+
+        FROM_SAML2_SETTING_MAP = {
+            constants.NAMEID_EMAIL_ADDRESS: EMAIL,
+            constants.NAMEID_ENTITY: ENTITY,
+            constants.NAMEID_TRANSIENT: TRANSIENT,
+            constants.NAMEID_PERSISTENT: PERSISTENT,
+            constants.NAMEID_UNSPECIFIED: UNSPECIFIED,
+        }
+    else:
+        TO_SAML2_SETTING_MAP = {}
+        FROM_SAML2_SETTING_MAP = {}
+
 def get_saml2_settings():
     """Return the SAML2.0 settings.
 
@@ -168,7 +209,8 @@ def get_saml2_settings():
                     reverse('sso:saml:sls', kwargs={'backend_id': 'saml'})),
                 'binding': constants.BINDING_HTTP_REDIRECT,
             },
-            'NameIDFormat': constants.NAMEID_PERSISTENT,
+            'NameIDFormat': NameIDFormat.TO_SAML2_SETTING_MAP[
+                siteconfig.get('saml_nameid_format')],
             'x509cert': '',
             'privateKey': '',
         },

--- a/reviewboard/accounts/sso/backends/saml/sso_backend.py
+++ b/reviewboard/accounts/sso/backends/saml/sso_backend.py
@@ -16,7 +16,8 @@ from reviewboard.accounts.sso.backends.saml.forms import SAMLSettingsForm
 from reviewboard.accounts.sso.backends.saml.settings import (
     SAMLBinding,
     SAMLDigestAlgorithm,
-    SAMLSignatureAlgorithm)
+    SAMLSignatureAlgorithm,
+    NameIDFormat)
 from reviewboard.accounts.sso.backends.saml.views import (
     SAMLACSView,
     SAMLLinkUserView,
@@ -47,6 +48,7 @@ class SAMLSSOBackend(BaseSSOBackend):
         'saml_sso_binding_type': SAMLBinding.HTTP_POST,
         'saml_sso_url': '',
         'saml_verfication_cert': '',
+        'saml_nameid_format': NameIDFormat.PERSISTENT,
     }
     login_view_cls = SAMLLoginView
 

--- a/reviewboard/accounts/sso/backends/saml/sso_backend.py
+++ b/reviewboard/accounts/sso/backends/saml/sso_backend.py
@@ -17,7 +17,8 @@ from reviewboard.accounts.sso.backends.saml.settings import (
     SAMLBinding,
     SAMLDigestAlgorithm,
     SAMLSignatureAlgorithm,
-    NameIDFormat)
+    NameIDFormat,
+    UserAttributeMapping)
 from reviewboard.accounts.sso.backends.saml.views import (
     SAMLACSView,
     SAMLLinkUserView,
@@ -49,6 +50,9 @@ class SAMLSSOBackend(BaseSSOBackend):
         'saml_sso_url': '',
         'saml_verfication_cert': '',
         'saml_nameid_format': NameIDFormat.PERSISTENT,
+        'saml_email_attribute_name': UserAttributeMapping.EMAIL,
+        'saml_firstname_attribute_name': UserAttributeMapping.FIRSTNAME,
+        'saml_lastname_attribute_name': UserAttributeMapping.LASTNAME,
     }
     login_view_cls = SAMLLoginView
 

--- a/reviewboard/accounts/tests/test_saml_forms.py
+++ b/reviewboard/accounts/tests/test_saml_forms.py
@@ -8,7 +8,8 @@ from reviewboard.accounts.sso.backends.saml.forms import (SAMLLinkUserForm,
 from reviewboard.accounts.sso.backends.saml.settings import (
     SAMLBinding,
     SAMLDigestAlgorithm,
-    SAMLSignatureAlgorithm)
+    SAMLSignatureAlgorithm,
+    NameIDFormat)
 from reviewboard.testing import TestCase
 
 
@@ -101,6 +102,7 @@ class SAMLSettingsFormTests(TestCase):
                 'saml_sso_binding_type': SAMLBinding.HTTP_POST,
                 'saml_slo_url': 'https://example.com/saml/slo',
                 'saml_slo_binding_type': SAMLBinding.HTTP_REDIRECT,
+                'saml_nameid_format': NameIDFormat.PERSISTENT,
                 'saml_require_login_to_link': False,
             })
 
@@ -126,4 +128,6 @@ class SAMLSettingsFormTests(TestCase):
                          'https://example.com/saml/slo')
         self.assertEqual(siteconfig.get('saml_slo_binding_type'),
                          SAMLBinding.HTTP_REDIRECT)
+        self.assertEqual(siteconfig.get('saml_nameid_format'),
+                         NameIDFormat.PERSISTENT)
         self.assertFalse(siteconfig.get('saml_require_login_to_link'))


### PR DESCRIPTION
Different IdPs have different NameID formats. This pr makes it able to switch between `email`, `entity`, `transient`, `persistent` and `unspecified` formats.

Also this pr makes it easier to integrate with custom IdPs by specifying arbitrary attribute names.

 